### PR TITLE
Add unit declarator to module declarations

### DIFF
--- a/lib/File/Compare.pm6
+++ b/lib/File/Compare.pm6
@@ -1,4 +1,4 @@
-module File::Compare:auth<labster>;
+unit module File::Compare:auth<labster>;
 use v6;
 
 my $MAX = 8*1024*1024;    # Default maximum bytes for .read


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.
