### PR TITLE
Use kebab-case in test function names

### DIFF
--- a/t/00-basic.t
+++ b/t/00-basic.t
@@ -11,6 +11,6 @@ nok files_are_equal("t/00-basic.t", "lib/File/Compare.pm6"), "inequality (are_eq
 
 ok files_are_equal("t/00-basic.t", "t/00-basic.t", chunk_size => 1024), "chunk size (are_equal)";
 ok files_are_different("t/00-basic.t", "lib/File/Compare.pm6", chunk_size => 2048), "chunk size (are_different)";
-dies_ok { files_are_equal("t/00-basic.t", "t/00-basic.t", chunk_size => -23) }, "bad chunk size";
+dies-ok { files_are_equal("t/00-basic.t", "t/00-basic.t", chunk_size => -23) }, "bad chunk size";
 
-dies_ok {say files_are_equal("t/doesn't exist", "lib/File/Compare.pm6") }, "nonexistent files";
+dies-ok {say files_are_equal("t/doesn't exist", "lib/File/Compare.pm6") }, "nonexistent files";

--- a/t/01-multiple.t
+++ b/t/01-multiple.t
@@ -35,11 +35,11 @@ is sort-arrays(compare_multiple_files(@filelist.push('t/test-files/camelia.ico')
    ["t/test-files/foobar-2.txt", "t/test-files/foobar.txt"] ),
 	"non-matching files not returned";
 
-dies_ok {say compare_multiple_files( [] )}, "empty array fails";
+dies-ok {say compare_multiple_files( [] )}, "empty array fails";
 
-dies_ok {compare_multiple_files( [Mu, Any] )}, "wrong file data type passed fails";
+dies-ok {compare_multiple_files( [Mu, Any] )}, "wrong file data type passed fails";
 
-dies_ok {compare_multiple_files( @filelist, chunk_size => -23 #`{Skidoo!} )}, "bad chunk_size parameter fails";
+dies-ok {compare_multiple_files( @filelist, chunk_size => -23 #`{Skidoo!} )}, "bad chunk_size parameter fails";
 
 is sort-arrays(compare_multiple_files(@filelist».IO)),
   (["t/test-files/empty1", "t/test-files/empty2"],


### PR DESCRIPTION
Test function names with underscores have been deprecated in favour of their
kebab-case variants.  The deprecated form will be removed in Rakudo 2015.09.
This change brings the test suite up to date with current Rakudo.
